### PR TITLE
fix: don't use private interfaces

### DIFF
--- a/and.ts
+++ b/and.ts
@@ -2,7 +2,7 @@ import type Assert from './types/assert'
 
 type $<T> = Assert<T>
 
-interface And {
+type And = {
   <A>(a: $<A>): $<A>
   <A, B>(a: $<A>, b: $<B>): $<A & B>
   <A, B, C>(a: $<A>, b: $<B>, c: $<C>): $<A & B & C>

--- a/sequence.ts
+++ b/sequence.ts
@@ -2,7 +2,7 @@ import type Assert from './types/assert'
 
 type $<A, B> = (a: A) => B
 
-interface Sequence {
+type Sequence = {
   <A>(a: Assert<A>): Assert<A>
   <A, B>(a: Assert<A>, b: $<A, B>): Assert<B>
   <A, B, C>(a: Assert<A>, b: $<A, B>, c: $<B, C>): Assert<C>


### PR DESCRIPTION
This change is necessary because, when reexporting  from this package, there's an error because And and Sequence are private names.
There's no error if they are anonymous types instead of interfaces.